### PR TITLE
V0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 All notable changes to the "action-setup-kube-tools" will be documented in this file.
 
 ## v0.7.0
-- Add fail-fast parameter (fail-fast:true by default) that allows you to choose to fail fast immediately when it fails to download (say due to a bad version) - [Issue#14](https://github.com/yokawasa/action-setup-kube-tools/issues/14)
-- Support tool version 'v' prefix. Prior to this, the action only accept the tool version without 'v' prefix, but now the action automatically add/remove the prefix as necessary
+- Add fail-fast parameter (fail-fast:true by default) that allows you to choose to fail fast immediately when it fails to download (say due to a bad version) - [#14](https://github.com/yokawasa/action-setup-kube-tools/issues/14)
+- Support tool version 'v' prefix. Prior to this, the action only accept the tool version without 'v' prefix, but now the action automatically add/remove the prefix as necessary - [#13](https://github.com/yokawasa/action-setup-kube-tools/issues/13)
 
 ## v0.6.0
-- add tools setup option to choose which tool to setup - [Issue#8](https://github.com/yokawasa/action-setup-kube-tools/issues/8)
+- add tools setup option to choose which tool to setup - [#8](https://github.com/yokawasa/action-setup-kube-tools/issues/8)
 - up default tool versions
   - kubectl: 1.20.2
   - kustomize: 4.0.5
@@ -16,25 +16,25 @@ All notable changes to the "action-setup-kube-tools" will be documented in this 
 
 ## v0.5.0
 
-- Add kube-score - [PR#10](https://github.com/yokawasa/action-setup-kube-tools/pull/10)
+- Add kube-score - [#10](https://github.com/yokawasa/action-setup-kube-tools/pull/10)
   - https://github.com/zegl/kube-score
 
 ## v0.4.0
 
 - Minor markdown cleanup
 - Bump `actions/checkout` to v2 in tests and documentation
-- Add Tilt and Skaffold - [PR#6](https://github.com/yokawasa/action-setup-kube-tools/pull/6)
+- Add Tilt and Skaffold - [#6](https://github.com/yokawasa/action-setup-kube-tools/pull/6)
   - https://tilt.dev
   - https://skaffold.dev
 
 ## v0.3.0
 
-- Add Rancher CLI - [PR#4](https://github.com/yokawasa/action-setup-kube-tools/pull/4)
+- Add Rancher CLI - [#4](https://github.com/yokawasa/action-setup-kube-tools/pull/4)
   - https://rancher.com/docs/rancher/v2.x/en/cli/
 
 ## v0.2.0
 
-- Bumps @actions/core from 1.2.0 to 1.2.6 - [PR#2](https://github.com/yokawasa/action-setup-kube-tools/pull/2)
+- Bumps @actions/core from 1.2.0 to 1.2.6 - [#2](https://github.com/yokawasa/action-setup-kube-tools/pull/2)
 
 ## v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "action-setup-kube-tools" will be documented in this file.
 
+## v0.7.0
+- Add fail-fast parameter (fail-fast:true by default) that allows you to choose to fail fast immediately when it fails to download (say due to a bad version) - [Issue#14](https://github.com/yokawasa/action-setup-kube-tools/issues/14)
+- Support tool version 'v' prefix. Prior to this, the action only accept the tool version without 'v' prefix, but now the action automatically add/remove the prefix as necessary
+
 ## v0.6.0
 - add tools setup option to choose which tool to setup - [Issue#8](https://github.com/yokawasa/action-setup-kube-tools/issues/8)
 - up default tool versions

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A GitHub Action that setup Kubernetes tools (kubectl, kustomize, helm, kubeval, 
 
 |Parameter|Required|Default Value|Description|
 |:--:|:--:|:--:|:--|
+|`fail-fast`|`false`|`true`| the action immediately fails when it fails to download (ie. due to a bad version) |
 |`setup-tools`|`false`|`""`|List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying `setup-tools` you can choose which tools the action setup. Supported separator is `return` in multi-line string. Supported tools are `kubectl`, `kustomize`, `helm`, `helmv3`,  `kubeval`, `conftest`, `yq`, `rancher`, `tilt`, `skaffold`, `kube-score`|
 |`kubectl`|`false`|`1.20.2`| kubectl version. kubectl vesion can be found [here](https://github.com/kubernetes/kubernetes/releases)|
 |`kustomize`|`false`|`4.0.5`| kustomize version. kustomize vesion can be found [here](https://github.com/kubernetes-sigs/kustomize/releases)|

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ A GitHub Action that setup Kubernetes tools (kubectl, kustomize, helm, kubeval, 
 |`skaffold`|`false`|`1.20.0`| Skaffold version. Skaffold vesion can be found [here](https://github.com/GoogleContainerTools/skaffold/releases)|
 |`kube-score`|`false`|`1.10.1`| kube-score version. kube-score vesion can be found [here](https://github.com/zegl/kube-score/releases)|
 
-> Supported Environments: Linux
-
+> - Supported Environments: Linux
+> - From v0.7.0, the action supports tool version 'v' prefix. Prior to v0.7.0, the action only accept the tool version without 'v' prefix but from v0.7.0 the action automatically add/remove the prefix as necessary
+> 
 ### Outputs
 |Parameter|Description|
 |:--:|:--|

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Specific versions for the commands can be setup by adding inputs parameters like
         kubectl: '1.17.1'
         kustomize: '3.7.0'
         helm: '2.16.7'
-        helmv3: '3.2.4'
+        helmv3: '3.5.2'
         kubeval: '0.14.0'
         conftest: '0.18.2'
         rancher: '2.4.10'
@@ -114,7 +114,7 @@ By specifying setup-tools you can choose which tools the action setup. Supported
           kustomize
           skaffold
         kubectl: '1.17.1'
-        helmv3: '3.2.4'
+        helmv3: '3.5.2'
         kustomize: '3.7.0'
         skaffold: '1.20.0'
     - run: |

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'Setup Kubernetes Tools'
 description: 'Setup Kubernetes tools: kubectl, kustomize, helm, kubeval, conftest, yq, rancher, tilt, skaffold, kube-score'
 author: 'Yoichi Kawasaki @yokawasa'
 inputs:
+  fail-fast:
+    required: false
+    default: 'true'
+    description: 'the action immediately fails when it fails to download (ie. due to a bad version)'
   setup-tools:
     required: false
     default: ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -1647,7 +1647,7 @@ function run() {
                     catch (exception) {
                         if (failFast) {
                             // eslint-disable-next-line no-console
-                            console.log(`fail fast and exiting ${tool.name}!`);
+                            console.log(`Exiting immediately (fail fast) - [Reason] ${exception}`);
                             process.exit(1);
                         }
                     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1630,7 +1630,9 @@ function run() {
                 // By default, the action setup all supported Kubernetes tools, which mean
                 // all tools can be setup when setuptools does not have any elements.
                 if (setupToolList.length === 0 || setupToolList.includes(tool.name)) {
-                    let toolVersion = core.getInput(tool.name, { required: false }).toLocaleUpperCase();
+                    let toolVersion = core
+                        .getInput(tool.name, { required: false })
+                        .toLowerCase();
                     if (toolVersion && toolVersion.startsWith('v')) {
                         toolVersion = toolVersion.substr(1);
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-kube-tools",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Github Action that install Kubernetes tools (kubectl, kustomize, helm, kubeval, conftest, yq, rancher) and cache them on the runner",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,7 +262,7 @@ async function run() {
       } catch (exception) {
         if (failFast) {
           // eslint-disable-next-line no-console
-          console.log(`fail fast and exiting ${tool.name}!`)
+          console.log(`Exiting immediately (fail fast) - [Reason] ${exception}`)
           process.exit(1)
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -224,6 +224,11 @@ async function run() {
     throw new Error('The action only support Linux OS!')
   }
 
+  let failFast = true
+  if (core.getInput('fail-fast', {required: false}).toLowerCase() === 'false') {
+    failFast = false
+  }
+
   let setupToolList: string[] = []
   const setupTools = core.getInput('setup-tools', {required: false}).trim()
   if (setupTools) {
@@ -241,13 +246,24 @@ async function run() {
     // By default, the action setup all supported Kubernetes tools, which mean
     // all tools can be setup when setuptools does not have any elements.
     if (setupToolList.length === 0 || setupToolList.includes(tool.name)) {
-      let toolVersion = core.getInput(tool.name, {required: false})
+      let toolVersion = core.getInput(tool.name, {required: false}).toLocaleUpperCase()
+      if (toolVersion && toolVersion.startsWith('v')) {
+        toolVersion = toolVersion.substr(1);
+      }
       if (!toolVersion) {
         toolVersion = tool.defaultVersion
       }
-      const cachedPath = await downloadTool(toolVersion, tool)
-      core.addPath(path.dirname(cachedPath))
-      toolPath = cachedPath
+      try {
+        const cachedPath = await downloadTool(toolVersion, tool)
+        core.addPath(path.dirname(cachedPath))
+        toolPath = cachedPath
+      } catch (exception) {
+        if (failFast) {
+          // eslint-disable-next-line no-console
+          console.log(`fail fast and exiting ${tool.name}!`)
+          process.exit(0)
+        }
+      }
     }
     core.setOutput(`${tool.name}-path`, toolPath)
   })

--- a/src/main.ts
+++ b/src/main.ts
@@ -246,9 +246,11 @@ async function run() {
     // By default, the action setup all supported Kubernetes tools, which mean
     // all tools can be setup when setuptools does not have any elements.
     if (setupToolList.length === 0 || setupToolList.includes(tool.name)) {
-      let toolVersion = core.getInput(tool.name, {required: false}).toLocaleUpperCase()
+      let toolVersion = core
+        .getInput(tool.name, {required: false})
+        .toLocaleUpperCase()
       if (toolVersion && toolVersion.startsWith('v')) {
-        toolVersion = toolVersion.substr(1);
+        toolVersion = toolVersion.substr(1)
       }
       if (!toolVersion) {
         toolVersion = tool.defaultVersion
@@ -261,7 +263,7 @@ async function run() {
         if (failFast) {
           // eslint-disable-next-line no-console
           console.log(`fail fast and exiting ${tool.name}!`)
-          process.exit(0)
+          process.exit(1)
         }
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,7 +248,7 @@ async function run() {
     if (setupToolList.length === 0 || setupToolList.includes(tool.name)) {
       let toolVersion = core
         .getInput(tool.name, {required: false})
-        .toLocaleUpperCase()
+        .toLowerCase()
       if (toolVersion && toolVersion.startsWith('v')) {
         toolVersion = toolVersion.substr(1)
       }


### PR DESCRIPTION
- Add fail-fast parameter (fail-fast:true by default) that allows you to choose to fail fast immediately when it fails to download (say due to a bad version) - [#14](https://github.com/yokawasa/action-setup-kube-tools/issues/14)
- Support tool version 'v' prefix. Prior to this, the action only accept the tool version without 'v' prefix, but now the action automatically add/remove the prefix as necessary - [#13](https://github.com/yokawasa/action-setup-kube-tools/issues/13)