### PR TITLE
v0.8.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         kubectl version --client
         kustomize version
         helm version --client
-        helmv3 version
+        helm version
         kubeval --version
         conftest --version
         yq --version
@@ -37,7 +37,7 @@ jobs:
         kubectl=${{steps.setup.outputs.kubectl-path}}
         kustomize=${{steps.setup.outputs.kustomize-path}}
         helm=${{steps.setup.outputs.helm-path}}
-        helmv3=${{steps.setup.outputs.helmv3-path}}
+        helmv2=${{steps.setup.outputs.helmv2-path}}
         kubeval=${{steps.setup.outputs.kubeval-path}}
         conftest=${{steps.setup.outputs.conftest-path}}
         yq=${{steps.setup.outputs.yq-path}}
@@ -48,8 +48,8 @@ jobs:
 
         ${kubectl} version --client
         ${kustomize} version
-        ${helm} version --client
-        ${helmv3} version 
+        ${helm} version
+        ${helmv2} version --client
         ${kubeval} --version 
         ${conftest} --version 
         ${yq} --version 
@@ -66,8 +66,8 @@ jobs:
       with: 
         kubectl: '1.17.1'
         kustomize: '3.7.0'
-        helm: '2.16.7'
-        helmv3: '3.2.4'
+        helm: '3.2.4'
+        helmv2: '2.16.7'
         kubeval: '0.16.1'
         conftest: '0.18.2'
         yq: '4.7.1'
@@ -79,8 +79,8 @@ jobs:
     - run: |
         kubectl version --client
         kustomize version
-        helm version --client
-        helmv3 version
+        helm version
+        helmv2 version --client
         kubeval --version
         conftest --version
         yq --version
@@ -92,7 +92,7 @@ jobs:
         kubectl=${{steps.setup.outputs.kubectl-path}}
         kustomize=${{steps.setup.outputs.kustomize-path}}
         helm=${{steps.setup.outputs.helm-path}}
-        helmv3=${{steps.setup.outputs.helmv3-path}}
+        helmv2=${{steps.setup.outputs.helmv2-path}}
         kubeval=${{steps.setup.outputs.kubeval-path}}
         conftest=${{steps.setup.outputs.conftest-path}}
         yq=${{steps.setup.outputs.yq-path}}
@@ -103,8 +103,8 @@ jobs:
 
         ${kubectl} version --client
         ${kustomize} version
-        ${helm} version --client
-        ${helmv3} version 
+        ${helm} version
+        ${helmv2} version --client
         ${kubeval} --version 
         ${conftest} --version 
         ${yq} --version 
@@ -121,24 +121,24 @@ jobs:
       with:
         setup-tools: |
           kubectl
-          helmv3
+          helm
           kustomize
           skaffold
         kubectl: '1.17.1'
-        helmv3: '3.2.4'
+        helm: '3.2.4'
         kustomize: '3.7.0'
         skaffold: '1.20.0'
       id: setup
     - run: |
         kubectl version --client
         kustomize version
-        helmv3 version
+        helm version
         skaffold version
     - run: |
         kubectl=${{steps.setup.outputs.kubectl-path}}
         kustomize=${{steps.setup.outputs.kustomize-path}}
         helm=${{steps.setup.outputs.helm-path}}
-        helmv3=${{steps.setup.outputs.helmv3-path}}
+        helmv2=${{steps.setup.outputs.helmv2-path}}
         kubeval=${{steps.setup.outputs.kubeval-path}}
         conftest=${{steps.setup.outputs.conftest-path}}
         yq=${{steps.setup.outputs.yq-path}}
@@ -154,10 +154,10 @@ jobs:
           ${kustomize} version
         fi
         if [ ! -z ${helm} ]; then
-          ${helm} version --client
+          ${helm} version
         fi
-        if [ ! -z ${helmv3} ]; then
-          ${helmv3} version 
+        if [ ! -z ${helmv2} ]; then
+          ${helmv2} version --client
         fi
         if [ ! -z ${kubeval} ]; then
           ${kubeval} --version 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "action-setup-kube-tools" will be documented in this file.
 
+## v0.8.0
+- remove `helmv3` parameter and install helm v3 with `helm` parameter - [#19](https://github.com/yokawasa/action-setup-kube-tools/pull/19)
+- Instead add `helmv2` parameter to install helm v2
+
 ## v0.7.1
 - fix: missing v prefix from kubeval and yq - [#16](https://github.com/yokawasa/action-setup-kube-tools/pull/16)
 - changed default versions: yq v4.7.1, kubeval v0.16.1

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ A GitHub Action that setup Kubernetes tools (kubectl, kustomize, helm, kubeval, 
 |`setup-tools`|`false`|`""`|List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying `setup-tools` you can choose which tools the action setup. Supported separator is `return` in multi-line string. Supported tools are `kubectl`, `kustomize`, `helm`, `helmv3`,  `kubeval`, `conftest`, `yq`, `rancher`, `tilt`, `skaffold`, `kube-score`|
 |`kubectl`|`false`|`1.20.2`| kubectl version. kubectl vesion can be found [here](https://github.com/kubernetes/kubernetes/releases)|
 |`kustomize`|`false`|`4.0.5`| kustomize version. kustomize vesion can be found [here](https://github.com/kubernetes-sigs/kustomize/releases)|
-|`helm`|`false`|`2.17.0`| helm version. helm vesion can be found [here](https://github.com/helm/helm/releases)|
-|`helmv3`|`false`|`3.5.2`| helm v3 version. helm v3 vesion can be found [here](https://github.com/helm/helm/releases)|
+|`helm`|`false`|`3.6.3`| helm v3 version. helm vesion can be found [here](https://github.com/helm/helm/releases)|
+|`helmv2`|`false`|`2.17.0`| helm v2 version. helm v3 vesion can be found [here](https://github.com/helm/helm/releases)|
 |`kubeval`|`false`|`0.16.1`| kubeval version (must be **0.16.1+**). kubeval vesion can be found [here](https://github.com/instrumenta/kubeval/releases)|
 |`conftest`|`false`|`0.19.0`| conftest version. conftest vesion can be found [here](https://github.com/open-policy-agent/conftest/releases)|
 |`yq`|`false`|`4.7.1`| yq version. yq vesion can be found [here](https://github.com/mikefarah/yq/releases/)|
@@ -34,7 +34,7 @@ A GitHub Action that setup Kubernetes tools (kubectl, kustomize, helm, kubeval, 
 |`kubectl-path`| kubectl command path if the action setup the tool, otherwise empty string |
 |`kustomize-path`| kustomize command path if the action setup the tool, otherwise empty string |
 |`helm-path`| helm command path if the action setup the tool, otherwise empty string |
-|`helmv3-path`| helm v3 command path if the action setup the tool, otherwise empty string |
+|`helmv2-path`| helm v2 command path if the action setup the tool, otherwise empty string |
 |`kubeval-path`| kubeval command path if the action setup the tool, otherwise empty string |
 |`conftest-path`| conftest command path if the action setup the tool, otherwise empty string |
 |`yq-path`| yq command path if the action setup the tool, otherwise empty string |
@@ -56,8 +56,8 @@ Specific versions for the commands can be setup by adding inputs parameters like
       with:
         kubectl: '1.17.1'
         kustomize: '3.7.0'
-        helm: '2.16.7'
-        helmv3: '3.5.2'
+        helm: '3.5.2'
+        helmv2: '2.16.7'
         kubeval: '0.16.1'
         conftest: '0.18.2'
         rancher: '2.4.10'
@@ -67,8 +67,8 @@ Specific versions for the commands can be setup by adding inputs parameters like
     - run: |
         kubectl version --client
         kustomize version
-        helm version --client
-        helmv3 version
+        helm version
+        helmv2 version --client
         kubeval --version
         conftest --version
         yq --version
@@ -89,8 +89,8 @@ Default versions for the commands will be setup if you don't give any inputs lik
     - run: |
         kubectl version --client
         kustomize version
-        helm version --client
-        helmv3 version
+        helm version
+        helmv2 version --client
         kubeval --version
         conftest --version
         yq --version
@@ -111,17 +111,17 @@ By specifying setup-tools you can choose which tools the action setup. Supported
       with:
         setup-tools: |
           kubectl
-          helmv3
+          helm
           kustomize
           skaffold
         kubectl: '1.17.1'
-        helmv3: '3.5.2'
+        helm: '3.5.2'
         kustomize: '3.7.0'
         skaffold: '1.20.0'
     - run: |
         kubectl version --client
         kustomize version
-        helmv3 version
+        helm version
         skaffold version
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -20,12 +20,12 @@ inputs:
     description: 'kustomize version'
   helm:
     required: false
-    default: '2.17.0'
-    description: 'helm version'
-  helmv3:
+    default: '3.6.3'
+    description: 'helm v3 version'
+  helmv2:
     required: false
-    default: '3.5.2'
-    description: 'helm3 version'
+    default: '2.17.0'
+    description: 'helm v2 version'
   kubeval:
     required: false
     default: '0.16.1'
@@ -61,8 +61,8 @@ outputs:
     description: 'kustomize command path if the action setup the tool, otherwise empty string'
   helm-path:
     description: 'helm command path if the action setup the tool, otherwise empty string'
-  helmv3-path:
-    description: 'helmv3 command path if the action setup the tool, otherwise empty string'
+  helmv2-path:
+    description: 'helmv2 command path if the action setup the tool, otherwise empty string'
   kubeval-path:
     description: 'kubeval command path if the action setup the tool, otherwise empty string'
   conftest-path:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1460,8 +1460,8 @@ const toolCache = __importStar(__webpack_require__(533));
 const core = __importStar(__webpack_require__(470));
 const defaultKubectlVersion = '1.20.2';
 const defaultKustomizeVersion = '4.0.5';
-const defaultHelmVersion = '2.17.0';
-const defaultHelmv3Version = '3.5.2';
+const defaultHelmVersion = '3.6.3';
+const defaultHelmv2Version = '2.17.0';
 const defaultKubevalVersion = '0.16.1';
 const defaultConftestVersion = '0.19.0';
 const defaultYqVersion = '4.7.1';
@@ -1489,8 +1489,8 @@ const Tools = [
         commandPathInPackage: 'linux-amd64/helm'
     },
     {
-        name: 'helmv3',
-        defaultVersion: defaultHelmv3Version,
+        name: 'helmv2',
+        defaultVersion: defaultHelmv2Version,
         isArchived: true,
         commandPathInPackage: 'linux-amd64/helm'
     },
@@ -1545,7 +1545,7 @@ function getDownloadURL(commandName, version) {
             return util.format('https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv%s/kustomize_v%s_linux_amd64.tar.gz', version, version);
         case 'helm':
             return util.format('https://get.helm.sh/helm-v%s-linux-amd64.tar.gz', version);
-        case 'helmv3':
+        case 'helmv2':
             return util.format('https://get.helm.sh/helm-v%s-linux-amd64.tar.gz', version);
         case 'kubeval':
             return util.format('https://github.com/instrumenta/kubeval/releases/download/v%s/kubeval-linux-amd64.tar.gz', version);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "action-setup-kube-tools",
-  "version": "0.4.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-kube-tools",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "description": "Github Action that install Kubernetes tools (kubectl, kustomize, helm, kubeval, conftest, yq, rancher) and cache them on the runner",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,8 @@ import * as core from '@actions/core'
 
 const defaultKubectlVersion = '1.20.2'
 const defaultKustomizeVersion = '4.0.5'
-const defaultHelmVersion = '2.17.0'
-const defaultHelmv3Version = '3.5.2'
+const defaultHelmVersion = '3.6.3'
+const defaultHelmv2Version = '2.17.0'
 const defaultKubevalVersion = '0.16.1'
 const defaultConftestVersion = '0.19.0'
 const defaultYqVersion = '4.7.1'
@@ -45,8 +45,8 @@ const Tools: Tool[] = [
     commandPathInPackage: 'linux-amd64/helm'
   },
   {
-    name: 'helmv3',
-    defaultVersion: defaultHelmv3Version,
+    name: 'helmv2',
+    defaultVersion: defaultHelmv2Version,
     isArchived: true,
     commandPathInPackage: 'linux-amd64/helm'
   },
@@ -112,7 +112,7 @@ function getDownloadURL(commandName: string, version: string): string {
         'https://get.helm.sh/helm-v%s-linux-amd64.tar.gz',
         version
       )
-    case 'helmv3':
+    case 'helmv2':
       return util.format(
         'https://get.helm.sh/helm-v%s-linux-amd64.tar.gz',
         version


### PR DESCRIPTION
- remove `helmv3` parameter and install helm v3 with `helm` parameter - [#18 ]
- Instead add `helmv2` parameter to install helm v2