### PR TITLE
Support arch type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,18 +196,6 @@ jobs:
         arch-type: 'arm64'
       id: setup
     - run: |
-        echo "kubectl: ${{steps.setup.outputs.kubectl-path}}"
-        echo "kustomize: ${{steps.setup.outputs.kustomize-path}}"
-        echo "helm: ${{steps.setup.outputs.helm-path}}"
-        echo "kubeval: ${{steps.setup.outputs.kubeval-path}}"
-        echo "kubeconform: ${{steps.setup.outputs.kubeconform-path}}"
-        echo "conftest: ${{steps.setup.outputs.conftest-path}}"
-        echo "yq: ${{steps.setup.outputs.yq-path}}"
-        echo "rancher: ${{steps.setup.outputs.rancher-path}}"
-        echo "tilt: ${{steps.setup.outputs.tilt-path}}"
-        echo "skaffold: ${{steps.setup.outputs.skaffold-path}}"
-        echo "kubescore: ${{steps.setup.outputs.kube-score-path}}"
-
         kubectl=${{steps.setup.outputs.kubectl-path}}
         kustomize=${{steps.setup.outputs.kustomize-path}}
         helm=${{steps.setup.outputs.helm-path}}
@@ -222,37 +210,35 @@ jobs:
 
         if [ ! -z ${kubectl} ]; then
           file ${kubectl}
-          ${kubectl} version --client
         fi
         if [ ! -z ${kustomize} ]; then
           file ${kustomize}
-          ${kustomize} version
         fi
         if [ ! -z ${helm} ]; then
-          ${helm} version
+          file ${helm}
         fi
         if [ ! -z ${kubeval} ]; then
-          ${kubeval} --version
+          file ${kubeval}
         fi
         if [ ! -z ${kubeconform} ]; then
-          ${kubeconform} -v
+          file ${kubeconform}
         fi
         if [ ! -z ${conftest} ]; then
-          ${conftest} --version
+          file ${conftest}
         fi
         if [ ! -z ${yq} ]; then
-          ${yq} --version
+          file ${yq}
         fi
         if [ ! -z ${rancher} ]; then
-          ${rancher} --version
+          file ${rancher}
         fi
         if [ ! -z ${tilt} ]; then
-          ${tilt} version
+          file ${tilt}
         fi
         if [ ! -z ${skaffold} ]; then
-          ${skaffold} version
+          file ${skaffold}
         fi
         if [ ! -z ${kubescore} ]; then
-          ${kubescore} version
+          file ${kubescore}
         fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,3 +207,38 @@ jobs:
         echo "tilt: ${{steps.setup.outputs.tilt-path}}"
         echo "skaffold: ${{steps.setup.outputs.skaffold-path}}"
         echo "kubescore: ${{steps.setup.outputs.kube-score-path}}"
+
+        if [ ! -z ${kubectl} ]; then
+          ${kubectl} version --client
+        fi
+        if [ ! -z ${kustomize} ]; then
+          ${kustomize} version
+        fi
+        if [ ! -z ${helm} ]; then
+          ${helm} version
+        fi
+        if [ ! -z ${kubeval} ]; then
+          ${kubeval} --version
+        fi
+        if [ ! -z ${kubeconform} ]; then
+          ${kubeconform} -v
+        fi
+        if [ ! -z ${conftest} ]; then
+          ${conftest} --version
+        fi
+        if [ ! -z ${yq} ]; then
+          ${yq} --version
+        fi
+        if [ ! -z ${rancher} ]; then
+          ${rancher} --version
+        fi
+        if [ ! -z ${tilt} ]; then
+          ${tilt} version
+        fi
+        if [ ! -z ${skaffold} ]; then
+          ${skaffold} version
+        fi
+        if [ ! -z ${kubescore} ]; then
+          ${kubescore} version
+        fi
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,7 +193,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./
       with:
-        arch-type: 'amd64'
+        arch-type: 'arm64'
       id: setup
     - run: |
         echo "kubectl: ${{steps.setup.outputs.kubectl-path}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: ./
       id: setup
     - run: |
-        kubectl version --output=json
+        kubectl version --client
         kustomize version
         helm version
         kubeval --version
@@ -49,7 +49,7 @@ jobs:
         skaffold=${{steps.setup.outputs.skaffold-path}}
         kubescore=${{steps.setup.outputs.kube-score-path}}
 
-        ${kubectl} version --output=json
+        ${kubectl} version --client
         ${kustomize} version
         ${helm} version
         ${kubeval} --version
@@ -80,7 +80,7 @@ jobs:
         kube-score: '1.10.1'
       id: setup
     - run: |
-        kubectl version --output=json
+        kubectl version --client
         kustomize version
         helm version
         kubeval --version
@@ -104,7 +104,7 @@ jobs:
         skaffold=${{steps.setup.outputs.skaffold-path}}
         kubescore=${{steps.setup.outputs.kube-score-path}}
 
-        ${kubectl} version --output=json
+        ${kubectl} version --client
         ${kustomize} version
         ${helm} version
         ${kubeval} --version
@@ -134,7 +134,7 @@ jobs:
         skaffold: '1.20.0'
       id: setup
     - run: |
-        kubectl version --output=json
+        kubectl version --client
         kustomize version
         helm version
         skaffold version
@@ -152,7 +152,7 @@ jobs:
         kubescore=${{steps.setup.outputs.kube-score-path}}
 
         if [ ! -z ${kubectl} ]; then
-          ${kubectl} version --output=json 
+          ${kubectl} version --client
         fi
         if [ ! -z ${kustomize} ]; then
           ${kustomize} version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,10 +208,24 @@ jobs:
         echo "skaffold: ${{steps.setup.outputs.skaffold-path}}"
         echo "kubescore: ${{steps.setup.outputs.kube-score-path}}"
 
+        kubectl=${{steps.setup.outputs.kubectl-path}}
+        kustomize=${{steps.setup.outputs.kustomize-path}}
+        helm=${{steps.setup.outputs.helm-path}}
+        kubeval=${{steps.setup.outputs.kubeval-path}}
+        kubeconform=${{steps.setup.outputs.kubeconform-path}}
+        conftest=${{steps.setup.outputs.conftest-path}}
+        yq=${{steps.setup.outputs.yq-path}}
+        rancher=${{steps.setup.outputs.rancher-path}}
+        tilt=${{steps.setup.outputs.tilt-path}}
+        skaffold=${{steps.setup.outputs.skaffold-path}}
+        kubescore=${{steps.setup.outputs.kube-score-path}}
+
         if [ ! -z ${kubectl} ]; then
+          file ${kubectl}
           ${kubectl} version --client
         fi
         if [ ! -z ${kustomize} ]; then
+          file ${kustomize}
           ${kustomize} version
         fi
         if [ ! -z ${helm} ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./
       with:
+        arch-type: 'amd64'
         setup-tools: |
           kubectl
           helm
@@ -184,3 +185,25 @@ jobs:
         if [ ! -z ${kubescore} ]; then
           ${kubescore} version
         fi
+
+  # ARM test
+  test4:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./
+      with:
+        arch-type: 'amd64'
+      id: setup
+    - run: |
+        echo "kubectl: ${{steps.setup.outputs.kubectl-path}}"
+        echo "kustomize: ${{steps.setup.outputs.kustomize-path}}"
+        echo "helm: ${{steps.setup.outputs.helm-path}}"
+        echo "kubeval: ${{steps.setup.outputs.kubeval-path}}"
+        echo "kubeconform: ${{steps.setup.outputs.kubeconform-path}}"
+        echo "conftest: ${{steps.setup.outputs.conftest-path}}"
+        echo "yq: ${{steps.setup.outputs.yq-path}}"
+        echo "rancher: ${{steps.setup.outputs.rancher-path}}"
+        echo "tilt: ${{steps.setup.outputs.tilt-path}}"
+        echo "skaffold: ${{steps.setup.outputs.skaffold-path}}"
+        echo "kubescore: ${{steps.setup.outputs.kube-score-path}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,8 @@ jobs:
     - uses: ./
       id: setup
     - run: |
-        kubectl version --client
+        kubectl version --output=json
         kustomize version
-        helm version --client
         helm version
         kubeval --version
         kubeconform -v
@@ -50,7 +49,7 @@ jobs:
         skaffold=${{steps.setup.outputs.skaffold-path}}
         kubescore=${{steps.setup.outputs.kube-score-path}}
 
-        ${kubectl} version --client
+        ${kubectl} version --output=json
         ${kustomize} version
         ${helm} version
         ${kubeval} --version
@@ -81,7 +80,7 @@ jobs:
         kube-score: '1.10.1'
       id: setup
     - run: |
-        kubectl version --client
+        kubectl version --output=json
         kustomize version
         helm version
         kubeval --version
@@ -105,7 +104,7 @@ jobs:
         skaffold=${{steps.setup.outputs.skaffold-path}}
         kubescore=${{steps.setup.outputs.kube-score-path}}
 
-        ${kubectl} version --client
+        ${kubectl} version --output=json
         ${kustomize} version
         ${helm} version
         ${kubeval} --version
@@ -135,7 +134,7 @@ jobs:
         skaffold: '1.20.0'
       id: setup
     - run: |
-        kubectl version --client
+        kubectl version --output=json
         kustomize version
         helm version
         skaffold version
@@ -153,7 +152,7 @@ jobs:
         kubescore=${{steps.setup.outputs.kube-score-path}}
 
         if [ ! -z ${kubectl} ]; then
-          ${kubectl} version --client
+          ${kubectl} version --output=json 
         fi
         if [ ! -z ${kustomize} ]; then
           ${kustomize} version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
         kubectl=${{steps.setup.outputs.kubectl-path}}
         kustomize=${{steps.setup.outputs.kustomize-path}}
         helm=${{steps.setup.outputs.helm-path}}
-        helmv2=${{steps.setup.outputs.helmv2-path}}
         kubeval=${{steps.setup.outputs.kubeval-path}}
         kubeconform=${{steps.setup.outputs.kubeconform-path}}
         conftest=${{steps.setup.outputs.conftest-path}}
@@ -54,7 +53,6 @@ jobs:
         ${kubectl} version --client
         ${kustomize} version
         ${helm} version
-        ${helmv2} version --client
         ${kubeval} --version
         ${kubeconform} -v
         ${conftest} --version
@@ -73,7 +71,6 @@ jobs:
         kubectl: '1.17.1'
         kustomize: '3.7.0'
         helm: '3.2.4'
-        helmv2: '2.16.7'
         kubeval: '0.16.1'
         kubeconform: '0.5.0'
         conftest: '0.18.2'
@@ -87,7 +84,6 @@ jobs:
         kubectl version --client
         kustomize version
         helm version
-        helmv2 version --client
         kubeval --version
         kubeconform -v
         conftest --version
@@ -100,7 +96,6 @@ jobs:
         kubectl=${{steps.setup.outputs.kubectl-path}}
         kustomize=${{steps.setup.outputs.kustomize-path}}
         helm=${{steps.setup.outputs.helm-path}}
-        helmv2=${{steps.setup.outputs.helmv2-path}}
         kubeval=${{steps.setup.outputs.kubeval-path}}
         kubeconform=${{steps.setup.outputs.kubeconform-path}}
         conftest=${{steps.setup.outputs.conftest-path}}
@@ -113,7 +108,6 @@ jobs:
         ${kubectl} version --client
         ${kustomize} version
         ${helm} version
-        ${helmv2} version --client
         ${kubeval} --version
         ${kubeconform} -v
         ${conftest} --version
@@ -148,7 +142,6 @@ jobs:
         kubectl=${{steps.setup.outputs.kubectl-path}}
         kustomize=${{steps.setup.outputs.kustomize-path}}
         helm=${{steps.setup.outputs.helm-path}}
-        helmv2=${{steps.setup.outputs.helmv2-path}}
         kubeval=${{steps.setup.outputs.kubeval-path}}
         kubeconform=${{steps.setup.outputs.kubeconform-path}}
         conftest=${{steps.setup.outputs.conftest-path}}
@@ -166,9 +159,6 @@ jobs:
         fi
         if [ ! -z ${helm} ]; then
           ${helm} version
-        fi
-        if [ ! -z ${helmv2} ]; then
-          ${helmv2} version --client
         fi
         if [ ! -z ${kubeval} ]; then
           ${kubeval} --version

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A GitHub Action that setup Kubernetes tools (kubectl, kustomize, helm, kubeconfo
 |Parameter|Required|Default Value|Description|
 |:--:|:--:|:--:|:--|
 |`fail-fast`|`false`|`true`| the action immediately fails when it fails to download (ie. due to a bad version) |
+|`arch-type`|`false`|`amd64`| The processor architecture type of the tool binary to setup. Supported types are only `amd64` and `arm64`. If a type other than the supported Types is specified, it will be treated as `amd64`.|
 |`setup-tools`|`false`|`""`|List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying `setup-tools` you can choose which tools the action setup. Supported separator is `return` in multi-line string. Supported tools are `kubectl`, `kustomize`, `helm`, `helmv3`,  `kubeval`, `conftest`, `yq`, `rancher`, `tilt`, `skaffold`, `kube-score`|
 |`kubectl`|`false`|`1.24.10`| kubectl version. kubectl vesion can be found [here](https://github.com/kubernetes/kubernetes/releases)|
 |`kustomize`|`false`|`5.0.0`| kustomize version. kustomize vesion can be found [here](https://github.com/kubernetes-sigs/kustomize/releases)|

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ A GitHub Action that setup Kubernetes tools (kubectl, kustomize, helm, kubeconfo
 |`setup-tools`|`false`|`""`|List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying `setup-tools` you can choose which tools the action setup. Supported separator is `return` in multi-line string. Supported tools are `kubectl`, `kustomize`, `helm`, `helmv3`,  `kubeval`, `conftest`, `yq`, `rancher`, `tilt`, `skaffold`, `kube-score`|
 |`kubectl`|`false`|`1.24.10`| kubectl version. kubectl vesion can be found [here](https://github.com/kubernetes/kubernetes/releases)|
 |`kustomize`|`false`|`5.0.0`| kustomize version. kustomize vesion can be found [here](https://github.com/kubernetes-sigs/kustomize/releases)|
-|`helm`|`false`|`3.11.1`| helm v3 version. helm vesion can be found [here](https://github.com/helm/helm/releases)|
-|`helmv2`|`false`|`2.17.0`| helm v2 version. helm v3 vesion can be found [here](https://github.com/helm/helm/releases)|
+|`helm`|`false`|`3.11.1`| helm version. helm vesion can be found [here](https://github.com/helm/helm/releases)|
 |`kubeval`|`false`|`0.16.1`| kubeval version (must be **0.16.1+**). kubeval vesion can be found [here](https://github.com/instrumenta/kubeval/releases).<br> NOTE: this parameter is deprecating as `kubeval` is no longer maintained. A good replacement is [kubeconform](https://github.com/yannh/kubeconform). See also [this](https://github.com/instrumenta/kubeval) for more details.|
 |`kubeconform`|`false`|`0.5.0`| kubeconform version. kubeconform vesion can be found [here](https://github.com/yannh/kubeconform/releases)|
 |`conftest`|`false`|`0.39.0`| conftest version. conftest vesion can be found [here](https://github.com/open-policy-agent/conftest/releases)|
@@ -34,7 +33,6 @@ A GitHub Action that setup Kubernetes tools (kubectl, kustomize, helm, kubeconfo
 |`kubectl-path`| kubectl command path if the action setup the tool, otherwise empty string |
 |`kustomize-path`| kustomize command path if the action setup the tool, otherwise empty string |
 |`helm-path`| helm command path if the action setup the tool, otherwise empty string |
-|`helmv2-path`| helm v2 command path if the action setup the tool, otherwise empty string |
 |`kubeval-path`| kubeval command path if the action setup the tool, otherwise empty string |
 |`kubeconform-path`| kubeconform command path if the action setup the tool, otherwise empty string |
 |`conftest-path`| conftest command path if the action setup the tool, otherwise empty string |
@@ -58,7 +56,6 @@ Specific versions for the commands can be setup by adding inputs parameters like
         kubectl: '1.17.1'
         kustomize: '3.7.0'
         helm: '3.5.2'
-        helmv2: '2.16.7'
         kubeconform: '0.5.0'
         conftest: '0.18.2'
         rancher: '2.4.10'
@@ -69,7 +66,6 @@ Specific versions for the commands can be setup by adding inputs parameters like
         kubectl version --client
         kustomize version
         helm version
-        helmv2 version --client
         kubeconform -v
         conftest --version
         yq --version
@@ -91,7 +87,6 @@ Default versions for the commands will be setup if you don't give any inputs lik
         kubectl version --client
         kustomize version
         helm version
-        helmv2 version --client
         kubeconform -v
         conftest --version
         yq --version

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     required: false
     default: 'true'
     description: 'the action immediately fails when it fails to download (ie. due to a bad version)'
+  arch-type:
+    required: false
+    default: 'amd64'
+    description: 'The processor architecture type of the tool binary to setup. Supported types are only "amd64" and "arm64". If a type other than the supported Types is specified, it will be treated as "amd64"'
   setup-tools:
     required: false
     default: ''
@@ -21,11 +25,7 @@ inputs:
   helm:
     required: false
     default: '3.11.1'
-    description: 'helm v3 version'
-  helmv2:
-    required: false
-    default: '2.17.0'
-    description: 'helm v2 version'
+    description: 'helm version'
   kubeval:
     required: false
     default: '0.16.1'
@@ -65,8 +65,6 @@ outputs:
     description: 'kustomize command path if the action setup the tool, otherwise empty string'
   helm-path:
     description: 'helm command path if the action setup the tool, otherwise empty string'
-  helmv2-path:
-    description: 'helmv2 command path if the action setup the tool, otherwise empty string'
   kubeval-path:
     description: 'kubeval command path if the action setup the tool, otherwise empty string'
   conftest-path:

--- a/dist/index.js
+++ b/dist/index.js
@@ -207,9 +207,6 @@ function downloadTool(version, archType, tool) {
                     const extractTarBaseDirPath = util.format('%s_%s', packagePath, tool.name);
                     fs.mkdirSync(extractTarBaseDirPath);
                     const extractedDirPath = yield toolCache.extractTar(packagePath, extractTarBaseDirPath);
-                    // if (commandPathInPackage.indexOf('%s') > 0) {
-                    //   commandPathInPackage = util.format(commandPathInPackage, version)
-                    // }
                     commandPathInPackage = replacePlaceholders(commandPathInPackage, version, archType);
                     commandPath = util.format('%s/%s', extractedDirPath, commandPathInPackage);
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -41,10 +41,10 @@ const util = __importStar(__nccwpck_require__(3837));
 const fs = __importStar(__nccwpck_require__(7147));
 const toolCache = __importStar(__nccwpck_require__(7784));
 const core = __importStar(__nccwpck_require__(2186));
+const defaultProcessorArchType = 'amd64';
 const defaultKubectlVersion = '1.24.10';
 const defaultKustomizeVersion = '5.0.0';
 const defaultHelmVersion = '3.11.1';
-const defaultHelmv2Version = '2.17.0';
 const defaultKubevalVersion = '0.16.1';
 const defaultKubeconformVersion = '0.5.0';
 const defaultConftestVersion = '0.39.0';
@@ -58,121 +58,159 @@ const Tools = [
         name: 'kubectl',
         defaultVersion: defaultKubectlVersion,
         isArchived: false,
+        supportArm: true,
         commandPathInPackage: 'kubectl'
     },
     {
         name: 'kustomize',
         defaultVersion: defaultKustomizeVersion,
         isArchived: true,
+        supportArm: true,
         commandPathInPackage: 'kustomize'
     },
     {
         name: 'helm',
         defaultVersion: defaultHelmVersion,
         isArchived: true,
-        commandPathInPackage: 'linux-amd64/helm'
-    },
-    {
-        name: 'helmv2',
-        defaultVersion: defaultHelmv2Version,
-        isArchived: true,
-        commandPathInPackage: 'linux-amd64/helm'
+        supportArm: true,
+        commandPathInPackage: 'linux-{arch}/helm'
     },
     {
         name: 'kubeval',
         defaultVersion: defaultKubevalVersion,
         isArchived: true,
+        supportArm: false,
         commandPathInPackage: 'kubeval'
     },
     {
         name: 'kubeconform',
         defaultVersion: defaultKubeconformVersion,
         isArchived: true,
+        supportArm: true,
         commandPathInPackage: 'kubeconform'
     },
     {
         name: 'conftest',
         defaultVersion: defaultConftestVersion,
         isArchived: true,
+        supportArm: true,
         commandPathInPackage: 'conftest'
     },
     {
         name: 'yq',
         defaultVersion: defaultYqVersion,
         isArchived: false,
-        commandPathInPackage: 'yq_linux_amd64'
+        supportArm: true,
+        commandPathInPackage: 'yq_linux_{arch}'
     },
     {
         name: 'rancher',
         defaultVersion: defaultRancherVersion,
         isArchived: true,
-        commandPathInPackage: 'rancher-v%s/rancher'
+        supportArm: true,
+        commandPathInPackage: 'rancher-v{ver}/rancher'
     },
     {
         name: 'tilt',
         defaultVersion: defaultTiltVersion,
         isArchived: true,
+        supportArm: true,
         commandPathInPackage: 'tilt'
     },
     {
         name: 'skaffold',
         defaultVersion: defaultSkaffoldVersion,
         isArchived: false,
-        commandPathInPackage: 'skaffold-linux-amd64'
+        supportArm: true,
+        commandPathInPackage: 'skaffold-linux-{arch}'
     },
     {
         name: 'kube-score',
         defaultVersion: defaultKubeScoreVersion,
         isArchived: false,
+        supportArm: true,
         commandPathInPackage: 'kube-score'
     }
 ];
-function getDownloadURL(commandName, version) {
+// Replace all {ver} and {arch} placeholders in the source format string with the actual values
+function replacePlaceholders(format, version, archType) {
+    return format.replace(/{ver}|{arch}/g, match => {
+        return match === '{ver}' ? version : archType;
+    });
+}
+function getDownloadURL(commandName, version, archType) {
+    let actualArchType = archType;
+    let urlFormat = '';
     switch (commandName) {
         case 'kubectl':
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/v%s/bin/linux/amd64/kubectl', version);
+            urlFormat =
+                'https://storage.googleapis.com/kubernetes-release/release/v{ver}/bin/linux/{arch}/kubectl';
+            break;
         case 'kustomize':
-            return util.format('https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv%s/kustomize_v%s_linux_amd64.tar.gz', version, version);
+            urlFormat =
+                'https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv{ver}/kustomize_v{ver}_linux_{arch}.tar.gz';
+            break;
         case 'helm':
-            return util.format('https://get.helm.sh/helm-v%s-linux-amd64.tar.gz', version);
-        case 'helmv2':
-            return util.format('https://get.helm.sh/helm-v%s-linux-amd64.tar.gz', version);
+            urlFormat = 'https://get.helm.sh/helm-v{ver}-linux-{arch}.tar.gz';
+            break;
         case 'kubeval':
-            return util.format('https://github.com/instrumenta/kubeval/releases/download/v%s/kubeval-linux-amd64.tar.gz', version);
+            actualArchType = 'amd64'; // kubeval only supports amd64
+            urlFormat =
+                'https://github.com/instrumenta/kubeval/releases/download/v{ver}/kubeval-linux-{arch}.tar.gz';
+            break;
         case 'kubeconform':
-            return util.format('https://github.com/yannh/kubeconform/releases/download/v%s/kubeconform-linux-amd64.tar.gz', version);
+            urlFormat =
+                'https://github.com/yannh/kubeconform/releases/download/v{ver}/kubeconform-linux-{arch}.tar.gz';
+            break;
         case 'conftest':
-            return util.format('https://github.com/open-policy-agent/conftest/releases/download/v%s/conftest_%s_Linux_x86_64.tar.gz', version, version);
+            actualArchType = archType === 'arm64' ? archType : 'x86_64';
+            urlFormat =
+                'https://github.com/open-policy-agent/conftest/releases/download/v{ver}/conftest_{ver}_Linux_{arch}.tar.gz';
+            break;
         case 'yq':
-            return util.format('https://github.com/mikefarah/yq/releases/download/v%s/yq_linux_amd64', version);
+            urlFormat =
+                'https://github.com/mikefarah/yq/releases/download/v{ver}/yq_linux_{arch}';
+            break;
         case 'rancher':
-            return util.format('https://github.com/rancher/cli/releases/download/v%s/rancher-linux-amd64-v%s.tar.gz', version, version);
+            actualArchType = archType === 'arm64' ? 'arm' : archType;
+            urlFormat =
+                'https://github.com/rancher/cli/releases/download/v{ver}/rancher-linux-{arch}-v{ver}.tar.gz';
+            break;
         case 'tilt':
-            return util.format('https://github.com/tilt-dev/tilt/releases/download/v%s/tilt.%s.linux.x86_64.tar.gz', version, version);
+            actualArchType = archType === 'arm64' ? archType : 'x86_64';
+            urlFormat =
+                'https://github.com/tilt-dev/tilt/releases/download/v{ver}/tilt.{ver}.linux.{arch}.tar.gz';
+            break;
         case 'skaffold':
-            return util.format('https://github.com/GoogleContainerTools/skaffold/releases/download/v%s/skaffold-linux-amd64', version);
+            urlFormat =
+                'https://github.com/GoogleContainerTools/skaffold/releases/download/v{ver}/skaffold-linux-{arch}';
+            break;
         case 'kube-score':
-            return util.format('https://github.com/zegl/kube-score/releases/download/v%s/kube-score_%s_linux_amd64', version, version);
+            urlFormat =
+                'https://github.com/zegl/kube-score/releases/download/v{ver}/kube-score_{ver}_linux_{arch}';
+            break;
         default:
             return '';
     }
+    return replacePlaceholders(urlFormat, version, actualArchType);
 }
-function downloadTool(version, tool) {
+function downloadTool(version, archType, tool) {
     return __awaiter(this, void 0, void 0, function* () {
         let cachedToolPath = toolCache.find(tool.name, version);
         let commandPathInPackage = tool.commandPathInPackage;
         let commandPath = '';
         if (!cachedToolPath) {
-            const downloadURL = getDownloadURL(tool.name, version);
+            const downloadURL = getDownloadURL(tool.name, version, archType);
             try {
                 const packagePath = yield toolCache.downloadTool(downloadURL);
                 if (tool.isArchived) {
                     const extractTarBaseDirPath = util.format('%s_%s', packagePath, tool.name);
                     fs.mkdirSync(extractTarBaseDirPath);
                     const extractedDirPath = yield toolCache.extractTar(packagePath, extractTarBaseDirPath);
-                    if (commandPathInPackage.indexOf('%s') > 0) {
-                        commandPathInPackage = util.format(commandPathInPackage, version);
-                    }
+                    // if (commandPathInPackage.indexOf('%s') > 0) {
+                    //   commandPathInPackage = util.format(commandPathInPackage, version)
+                    // }
+                    commandPathInPackage = replacePlaceholders(commandPathInPackage, version, archType);
                     commandPath = util.format('%s/%s', extractedDirPath, commandPathInPackage);
                 }
                 else {
@@ -205,6 +243,10 @@ function run() {
         if (core.getInput('fail-fast', { required: false }).toLowerCase() === 'false') {
             failFast = false;
         }
+        let archType = defaultProcessorArchType;
+        if (core.getInput('arch-type', { required: false }).toLowerCase() === 'arm64') {
+            archType = 'arm64';
+        }
         let setupToolList = [];
         const setupTools = core.getInput('setup-tools', { required: false }).trim();
         if (setupTools) {
@@ -231,8 +273,13 @@ function run() {
                     if (!toolVersion) {
                         toolVersion = tool.defaultVersion;
                     }
+                    if (archType === 'arm64' && !tool.supportArm) {
+                        // eslint-disable-next-line no-console
+                        console.log(`The ${tool.name} does not support arm64 architecture, skip it`);
+                        return;
+                    }
                     try {
-                        const cachedPath = yield downloadTool(toolVersion, tool);
+                        const cachedPath = yield downloadTool(toolVersion, archType, tool);
                         core.addPath(path.dirname(cachedPath));
                         toolPath = cachedPath;
                     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -209,9 +209,6 @@ async function downloadTool(
           extractTarBaseDirPath
         )
 
-        // if (commandPathInPackage.indexOf('%s') > 0) {
-        //   commandPathInPackage = util.format(commandPathInPackage, version)
-        // }
         commandPathInPackage = replacePlaceholders(
           commandPathInPackage,
           version,

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,10 +6,11 @@ import * as fs from 'fs'
 import * as toolCache from '@actions/tool-cache'
 import * as core from '@actions/core'
 
+const defaultProcessorArchType = 'amd64'
+
 const defaultKubectlVersion = '1.24.10'
 const defaultKustomizeVersion = '5.0.0'
 const defaultHelmVersion = '3.11.1'
-const defaultHelmv2Version = '2.17.0'
 const defaultKubevalVersion = '0.16.1'
 const defaultKubeconformVersion = '0.5.0'
 const defaultConftestVersion = '0.39.0'
@@ -23,6 +24,7 @@ interface Tool {
   name: string
   defaultVersion: string
   isArchived: boolean
+  supportArm: boolean
   commandPathInPackage: string
 }
 
@@ -31,155 +33,164 @@ const Tools: Tool[] = [
     name: 'kubectl',
     defaultVersion: defaultKubectlVersion,
     isArchived: false,
+    supportArm: true,
     commandPathInPackage: 'kubectl'
   },
   {
     name: 'kustomize',
     defaultVersion: defaultKustomizeVersion,
     isArchived: true,
+    supportArm: true,
     commandPathInPackage: 'kustomize'
   },
   {
     name: 'helm',
     defaultVersion: defaultHelmVersion,
     isArchived: true,
-    commandPathInPackage: 'linux-amd64/helm'
-  },
-  {
-    name: 'helmv2',
-    defaultVersion: defaultHelmv2Version,
-    isArchived: true,
-    commandPathInPackage: 'linux-amd64/helm'
+    supportArm: true,
+    commandPathInPackage: 'linux-{arch}/helm'
   },
   {
     name: 'kubeval',
     defaultVersion: defaultKubevalVersion,
     isArchived: true,
+    supportArm: false,
     commandPathInPackage: 'kubeval'
   },
   {
     name: 'kubeconform',
     defaultVersion: defaultKubeconformVersion,
     isArchived: true,
+    supportArm: true,
     commandPathInPackage: 'kubeconform'
   },
   {
     name: 'conftest',
     defaultVersion: defaultConftestVersion,
     isArchived: true,
+    supportArm: true,
     commandPathInPackage: 'conftest'
   },
   {
     name: 'yq',
     defaultVersion: defaultYqVersion,
     isArchived: false,
-    commandPathInPackage: 'yq_linux_amd64'
+    supportArm: true,
+    commandPathInPackage: 'yq_linux_{arch}'
   },
   {
     name: 'rancher',
     defaultVersion: defaultRancherVersion,
     isArchived: true,
-    commandPathInPackage: 'rancher-v%s/rancher'
+    supportArm: true,
+    commandPathInPackage: 'rancher-v{ver}/rancher'
   },
   {
     name: 'tilt',
     defaultVersion: defaultTiltVersion,
     isArchived: true,
+    supportArm: true,
     commandPathInPackage: 'tilt'
   },
   {
     name: 'skaffold',
     defaultVersion: defaultSkaffoldVersion,
     isArchived: false,
-    commandPathInPackage: 'skaffold-linux-amd64'
+    supportArm: true,
+    commandPathInPackage: 'skaffold-linux-{arch}'
   },
   {
     name: 'kube-score',
     defaultVersion: defaultKubeScoreVersion,
     isArchived: false,
+    supportArm: true,
     commandPathInPackage: 'kube-score'
   }
 ]
 
-function getDownloadURL(commandName: string, version: string): string {
+// Replace all {ver} and {arch} placeholders in the source format string with the actual values
+function replacePlaceholders(
+  format: string,
+  version: string,
+  archType: string
+): string {
+  return format.replace(/{ver}|{arch}/g, match => {
+    return match === '{ver}' ? version : archType
+  })
+}
+
+function getDownloadURL(
+  commandName: string,
+  version: string,
+  archType: string
+): string {
+  let actualArchType = archType
+  let urlFormat = ''
   switch (commandName) {
     case 'kubectl':
-      return util.format(
-        'https://storage.googleapis.com/kubernetes-release/release/v%s/bin/linux/amd64/kubectl',
-        version
-      )
+      urlFormat =
+        'https://storage.googleapis.com/kubernetes-release/release/v{ver}/bin/linux/{arch}/kubectl'
+      break
     case 'kustomize':
-      return util.format(
-        'https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv%s/kustomize_v%s_linux_amd64.tar.gz',
-        version,
-        version
-      )
+      urlFormat =
+        'https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv{ver}/kustomize_v{ver}_linux_{arch}.tar.gz'
+      break
     case 'helm':
-      return util.format(
-        'https://get.helm.sh/helm-v%s-linux-amd64.tar.gz',
-        version
-      )
-    case 'helmv2':
-      return util.format(
-        'https://get.helm.sh/helm-v%s-linux-amd64.tar.gz',
-        version
-      )
+      urlFormat = 'https://get.helm.sh/helm-v{ver}-linux-{arch}.tar.gz'
+      break
     case 'kubeval':
-      return util.format(
-        'https://github.com/instrumenta/kubeval/releases/download/v%s/kubeval-linux-amd64.tar.gz',
-        version
-      )
+      actualArchType = 'amd64' // kubeval only supports amd64
+      urlFormat =
+        'https://github.com/instrumenta/kubeval/releases/download/v{ver}/kubeval-linux-{arch}.tar.gz'
+      break
     case 'kubeconform':
-      return util.format(
-        'https://github.com/yannh/kubeconform/releases/download/v%s/kubeconform-linux-amd64.tar.gz',
-        version
-      )
+      urlFormat =
+        'https://github.com/yannh/kubeconform/releases/download/v{ver}/kubeconform-linux-{arch}.tar.gz'
+      break
     case 'conftest':
-      return util.format(
-        'https://github.com/open-policy-agent/conftest/releases/download/v%s/conftest_%s_Linux_x86_64.tar.gz',
-        version,
-        version
-      )
+      actualArchType = archType === 'arm64' ? archType : 'x86_64'
+      urlFormat =
+        'https://github.com/open-policy-agent/conftest/releases/download/v{ver}/conftest_{ver}_Linux_{arch}.tar.gz'
+      break
     case 'yq':
-      return util.format(
-        'https://github.com/mikefarah/yq/releases/download/v%s/yq_linux_amd64',
-        version
-      )
+      urlFormat =
+        'https://github.com/mikefarah/yq/releases/download/v{ver}/yq_linux_{arch}'
+      break
     case 'rancher':
-      return util.format(
-        'https://github.com/rancher/cli/releases/download/v%s/rancher-linux-amd64-v%s.tar.gz',
-        version,
-        version
-      )
+      actualArchType = archType === 'arm64' ? 'arm' : archType
+      urlFormat =
+        'https://github.com/rancher/cli/releases/download/v{ver}/rancher-linux-{arch}-v{ver}.tar.gz'
+      break
     case 'tilt':
-      return util.format(
-        'https://github.com/tilt-dev/tilt/releases/download/v%s/tilt.%s.linux.x86_64.tar.gz',
-        version,
-        version
-      )
+      actualArchType = archType === 'arm64' ? archType : 'x86_64'
+      urlFormat =
+        'https://github.com/tilt-dev/tilt/releases/download/v{ver}/tilt.{ver}.linux.{arch}.tar.gz'
+      break
     case 'skaffold':
-      return util.format(
-        'https://github.com/GoogleContainerTools/skaffold/releases/download/v%s/skaffold-linux-amd64',
-        version
-      )
+      urlFormat =
+        'https://github.com/GoogleContainerTools/skaffold/releases/download/v{ver}/skaffold-linux-{arch}'
+      break
     case 'kube-score':
-      return util.format(
-        'https://github.com/zegl/kube-score/releases/download/v%s/kube-score_%s_linux_amd64',
-        version,
-        version
-      )
+      urlFormat =
+        'https://github.com/zegl/kube-score/releases/download/v{ver}/kube-score_{ver}_linux_{arch}'
+      break
     default:
       return ''
   }
+  return replacePlaceholders(urlFormat, version, actualArchType)
 }
 
-async function downloadTool(version: string, tool: Tool): Promise<string> {
+async function downloadTool(
+  version: string,
+  archType: string,
+  tool: Tool
+): Promise<string> {
   let cachedToolPath = toolCache.find(tool.name, version)
   let commandPathInPackage = tool.commandPathInPackage
   let commandPath = ''
 
   if (!cachedToolPath) {
-    const downloadURL = getDownloadURL(tool.name, version)
+    const downloadURL = getDownloadURL(tool.name, version, archType)
 
     try {
       const packagePath = await toolCache.downloadTool(downloadURL)
@@ -198,9 +209,14 @@ async function downloadTool(version: string, tool: Tool): Promise<string> {
           extractTarBaseDirPath
         )
 
-        if (commandPathInPackage.indexOf('%s') > 0) {
-          commandPathInPackage = util.format(commandPathInPackage, version)
-        }
+        // if (commandPathInPackage.indexOf('%s') > 0) {
+        //   commandPathInPackage = util.format(commandPathInPackage, version)
+        // }
+        commandPathInPackage = replacePlaceholders(
+          commandPathInPackage,
+          version,
+          archType
+        )
         commandPath = util.format(
           '%s/%s',
           extractedDirPath,
@@ -241,6 +257,11 @@ async function run() {
     failFast = false
   }
 
+  let archType = defaultProcessorArchType
+  if (core.getInput('arch-type', {required: false}).toLowerCase() === 'arm64') {
+    archType = 'arm64'
+  }
+
   let setupToolList: string[] = []
   const setupTools = core.getInput('setup-tools', {required: false}).trim()
   if (setupTools) {
@@ -267,8 +288,16 @@ async function run() {
       if (!toolVersion) {
         toolVersion = tool.defaultVersion
       }
+      if (archType === 'arm64' && !tool.supportArm) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `The ${tool.name} does not support arm64 architecture, skip it`
+        )
+        return
+      }
+
       try {
-        const cachedPath = await downloadTool(toolVersion, tool)
+        const cachedPath = await downloadTool(toolVersion, archType, tool)
         core.addPath(path.dirname(cachedPath))
         toolPath = cachedPath
       } catch (exception) {


### PR DESCRIPTION
# Overview

Add new `arch-type` parameter for the processor architecture type of the tool binary to setup.
- Supported types are only `amd64` and `arm64`. 
- If a type other than the supported Types is specified, it will be treated as `amd64`

```yaml
  test: 
    steps:
    - uses: actions/checkout@v4
    - uses: yokawasa/action-setup-kube-tools@v0.11.0
      with:
        arch-type: 'arm64'
        setup-tools: |
          kubectl
        kubectl: '1.25'
    - run: |
        kubectl version --client
```

Relevant issue: https://github.com/yokawasa/action-setup-kube-tools/issues/47

Test: https://github.com/yokawasa/action-setup-kube-tools/actions/runs/8026979321/job/21930328628