### PR TITLE
Change kubectl download url, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Specific versions for the commands can be setup by adding inputs parameters like
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: yokawasa/action-setup-kube-tools@v0.12.0
+    - uses: yokawasa/action-setup-kube-tools@v0.11.1
       with:
         kubectl: '1.25'
         kustomize: '5.0.0'
@@ -82,7 +82,7 @@ Default versions for the commands will be setup if you don't give any inputs lik
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: yokawasa/action-setup-kube-tools@v0.12.0
+    - uses: yokawasa/action-setup-kube-tools@v0.11.1
     - run: |
         kubectl version --client
         kustomize version
@@ -103,7 +103,7 @@ By specifying setup-tools you can choose which tools the action setup. Supported
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: yokawasa/action-setup-kube-tools@v0.12.0
+    - uses: yokawasa/action-setup-kube-tools@v0.11.1
       with:
         setup-tools: |
           kubectl
@@ -127,7 +127,7 @@ By specifying arch-type you can choose the processor architecture type of the to
   test: 
     steps:
     - uses: actions/checkout@v4
-    - uses: yokawasa/action-setup-kube-tools@v0.12.0
+    - uses: yokawasa/action-setup-kube-tools@v0.11.1
       with:
         arch-type: 'arm64'
         setup-tools: |
@@ -163,7 +163,7 @@ Finally push the results
 ```
 git add dist
 git commit -a -m "prod dependencies"
-git push origin releases/v0.12.0
+git push origin releases/v0.11.1
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Specific versions for the commands can be setup by adding inputs parameters like
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: yokawasa/action-setup-kube-tools@v0.11.1
+    - uses: yokawasa/action-setup-kube-tools@v0.12.0
       with:
         kubectl: '1.25'
         kustomize: '5.0.0'
@@ -82,7 +82,7 @@ Default versions for the commands will be setup if you don't give any inputs lik
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: yokawasa/action-setup-kube-tools@v0.11.1
+    - uses: yokawasa/action-setup-kube-tools@v0.12.0
     - run: |
         kubectl version --client
         kustomize version
@@ -103,7 +103,7 @@ By specifying setup-tools you can choose which tools the action setup. Supported
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: yokawasa/action-setup-kube-tools@v0.11.1
+    - uses: yokawasa/action-setup-kube-tools@v0.12.0
       with:
         setup-tools: |
           kubectl
@@ -127,7 +127,7 @@ By specifying arch-type you can choose the processor architecture type of the to
   test: 
     steps:
     - uses: actions/checkout@v4
-    - uses: yokawasa/action-setup-kube-tools@v0.11.1
+    - uses: yokawasa/action-setup-kube-tools@v0.12.0
       with:
         arch-type: 'arm64'
         setup-tools: |
@@ -163,7 +163,7 @@ Finally push the results
 ```
 git add dist
 git commit -a -m "prod dependencies"
-git push origin releases/v0.11.1
+git push origin releases/v0.12.0
 ```
 
 ## References

--- a/dist/index.js
+++ b/dist/index.js
@@ -144,7 +144,7 @@ function getDownloadURL(commandName, version, archType) {
     switch (commandName) {
         case 'kubectl':
             urlFormat =
-                'https://storage.googleapis.com/kubernetes-release/release/v{ver}/bin/linux/{arch}/kubectl';
+                'https://dl.k8s.io/release/v{ver}/bin/linux/{arch}/kubectl';
             break;
         case 'kustomize':
             urlFormat =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-kube-tools",
-  "version": "0.12.0",
+  "version": "0.11.1",
   "private": true,
   "description": "Github Action that install Kubernetes tools (kubectl, kustomize, helm, kubeconform, conftest, yq, etc.) and cache them on the runner",
   "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-kube-tools",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "Github Action that install Kubernetes tools (kubectl, kustomize, helm, kubeconform, conftest, yq, etc.) and cache them on the runner",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,8 +128,7 @@ function getDownloadURL(
   let urlFormat = ''
   switch (commandName) {
     case 'kubectl':
-      urlFormat =
-        'https://storage.googleapis.com/kubernetes-release/release/v{ver}/bin/linux/{arch}/kubectl'
+      urlFormat = 'https://dl.k8s.io/release/v{ver}/bin/linux/{arch}/kubectl'
       break
     case 'kustomize':
       urlFormat =


### PR DESCRIPTION
Latest version v0.11.1 cannot download kubectl in version 1.30.5 and fails with error.
I have changed download url for the official docs and it works correctly even for older versions.
chore: fix missing version change in `package.json`
Fixes #62