### PR TITLE
Pinned to immutable commit SHAs to all references in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-node@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: '24.x'
     - run: |
@@ -24,7 +24,7 @@ jobs:
   test-all-tools-no-input:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - uses: ./
       id: setup
     - run: |
@@ -67,7 +67,7 @@ jobs:
   test-all-tools-with-versrion-input:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - uses: ./
       with:
         kubectl: '1.17.1'
@@ -122,7 +122,7 @@ jobs:
   test-with-some-tools-selected-and-latest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - uses: ./
       with:
         arch-type: 'amd64'
@@ -192,7 +192,7 @@ jobs:
   test-force-arm64:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - uses: ./
       with:
         arch-type: 'arm64'
@@ -234,7 +234,7 @@ jobs:
   test-arm-autodetect:
     runs-on: ubuntu-24.04-arm
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Show runner arch
       run: |
         echo "runner.os=${{ runner.os }}"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/test.yml` to use specific commit SHAs for the `actions/checkout` and `actions/setup-node` actions instead of just version tags. This change improves the security and reliability of the workflow by ensuring that a known, immutable version of each action is used.

**Workflow dependency pinning:**

* Updated all instances of `actions/checkout@v6` to use the specific commit SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd` for improved security and reproducibility. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L17-R18) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L27-R27) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L70-R70) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L125-R125) [[5]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L195-R195) [[6]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L237-R237)
* Updated `actions/setup-node@v6` to use the specific commit SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` in the build job.