### PR TITLE
Add version-file input to set tool versions from a .tool-versions file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,6 +188,38 @@ jobs:
           ${kubescore} version
         fi
 
+  test-version-file:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - name: Create .tool-versions
+      run: |
+        cat > .tool-versions <<'EOF'
+        # versions pinned via .tool-versions
+        kubectl 1.30.0
+        helm 3.14.4
+        yq 4.44.1
+        nodejs 20.0.0
+        EOF
+    - uses: ./
+      with:
+        version-file: '.tool-versions'
+        setup-tools: |
+          kubectl
+          helm
+          yq
+        # explicit input must override the version-file entry
+        kubectl: '1.31.0'
+      id: setup
+    - name: Verify version-file precedence
+      run: |
+        echo "kubectl (explicit override wins):"
+        kubectl version --client 2>&1 | grep -F '1.31.0'
+        echo "helm (from version-file):"
+        helm version 2>&1 | grep -F '3.14.4'
+        echo "yq (from version-file):"
+        yq --version 2>&1 | grep -F '4.44.1'
+
   # ARM test (force ARM64 artifacts on x64 runner)
   test-force-arm64:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A GitHub Action that setup Kubernetes tools (kubectl, kustomize, helm, kubeconfo
 |`fail-fast`|`false`|`true`| the action immediately fails when it fails to download (ie. due to a bad version) |
 |`arch-type`|`false`|`""`| Optional. The processor architecture type of the tool binary to setup. The action will auto-detect the architecture (`amd64` or `arm64`) and use it as appropriate at runtime. Specify the architecture type (`amd64` or `arm64`) only if you need to force it.|
 |`setup-tools`|`false`|`""`|List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying `setup-tools` you can choose which tools the action setup. Supported separator is `return` in multi-line string. Supported tools are `kubectl`, `kustomize`, `helm`, `kubeval`, `conftest`, `yq`, `rancher`, `tilt`, `skaffold`, `kube-score`|
+|`version-file`|`false`|`""`| Optional. Path to a `.tool-versions` ([asdf](https://asdf-vm.com/)/[mise](https://mise.jdx.dev/)) style file. For each supported tool with an entry in the file, that version is used **unless** the tool's own version input is explicitly set. Resolution order: explicit tool input > `version-file` entry > built-in default. Each line is `<tool> <version>`; `#` comments, blank lines, and unsupported tool names are ignored. See [Using a version file](#using-a-version-file).|
 |`kubectl`|`false`|`1.35.3`| kubectl version or `latest`. kubectl versions can be found [here](https://github.com/kubernetes/kubernetes/releases)|
 |`kustomize`|`false`|`5.8.1`| kustomize version or `latest`. kustomize versions can be found [here](https://github.com/kubernetes-sigs/kustomize/releases)|
 |`helm`|`false`|`3.20.1`| helm version or `latest`. helm versions can be found [here](https://github.com/helm/helm/releases)|
@@ -180,6 +181,47 @@ Explicit latest inputs (optional):
 ```
 
 Note: Using `latest` makes builds non-reproducible since versions can change over time. Prefer pinning exact versions for stability.
+
+### Using a version file
+
+If you already pin tool versions in a `.tool-versions` file (the [asdf](https://asdf-vm.com/)/[mise](https://mise.jdx.dev/) format), point `version-file` at it instead of repeating each version in the workflow:
+
+```
+# .tool-versions
+kubectl 1.30.0
+helm 3.15.0
+kustomize 5.4.0
+# unsupported tools and comments are ignored
+nodejs 20.0.0
+```
+
+```yaml
+  test:
+    steps:
+    - uses: actions/checkout@v4
+    - uses: yokawasa/action-setup-kube-tools@v0.13.5
+      with:
+        version-file: '.tool-versions'
+    - run: |
+        kubectl version --client
+        helm version
+        kustomize version
+```
+
+A tool's own version input always overrides its `version-file` entry, so you can pin most versions in the file and selectively override one in the workflow:
+
+```yaml
+  test:
+    steps:
+    - uses: actions/checkout@v4
+    - uses: yokawasa/action-setup-kube-tools@v0.13.5
+      with:
+        version-file: '.tool-versions'
+        # kubectl from .tool-versions is overridden here; helm/kustomize still come from the file
+        kubectl: '1.31.0'
+```
+
+Resolution order is: explicit tool input > `version-file` entry > built-in default. Tools without an entry in the file (and without an explicit input) fall back to their built-in default version.
 
 
 ## Developing the action

--- a/action.yml
+++ b/action.yml
@@ -13,50 +13,43 @@ inputs:
     required: false
     default: ''
     description: 'List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying "setup-tools" you can choose which tools the action setup. Supported separator is return in multi-line string. Supported tools are "kubectl", "kustomize", "helm", "helmv3", "kubeval", "conftest", "yq", "rancher", "tilt", "skaffold", "kube-score"'
+  version-file:
+    required: false
+    default: ''
+    description: 'Optional. Path to a ".tool-versions" (asdf/mise) style file. For each supported tool that has an entry in the file, that version is used, unless the tool''s own version input is explicitly set. Resolution order is: explicit tool input > version-file entry > built-in default. Each line is "<tool> <version>"; "#" comments, blank lines, and unsupported tool names are ignored.'
   kubectl:
     required: false
-    default: '1.35.3'
-    description: "kubectl version or 'latest'"
+    description: "kubectl version or 'latest' (default: 1.35.3)"
   kustomize:
     required: false
-    default: '5.8.1'
-    description: "kustomize version or 'latest'"
+    description: "kustomize version or 'latest' (default: 5.8.1)"
   helm:
     required: false
-    default: '3.20.1'
-    description: "helm version or 'latest'"
+    description: "helm version or 'latest' (default: 3.20.1)"
   kubeval:
     required: false
-    default: '0.16.1'
-    description: "kubeval version or 'latest'"
+    description: "kubeval version or 'latest' (default: 0.16.1)"
   kubeconform:
     required: false
-    default: '0.7.0'
-    description: "kubeconform version or 'latest'"
+    description: "kubeconform version or 'latest' (default: 0.7.0)"
   conftest:
     required: false
-    default: '0.67.1'
-    description: "conftest version or 'latest'"
+    description: "conftest version or 'latest' (default: 0.67.1)"
   yq:
     required: false
-    default: '4.52.5'
-    description: "yq version or 'latest'"
+    description: "yq version or 'latest' (default: 4.52.5)"
   rancher:
     required: false
-    default: '2.13.3'
-    description: "rancher cli version or 'latest'"
+    description: "rancher cli version or 'latest' (default: 2.13.3)"
   tilt:
     required: false
-    default: '0.37.0'
-    description: "tilt version or 'latest'"
+    description: "tilt version or 'latest' (default: 0.37.0)"
   skaffold:
     required: false
-    default: '2.18.1'
-    description: "skaffold version or 'latest'"
+    description: "skaffold version or 'latest' (default: 2.18.1)"
   kube-score:
     required: false
-    default: '1.20.0'
-    description: "kube-score version or 'latest'"
+    description: "kube-score version or 'latest' (default: 1.20.0)"
 outputs:
   kubectl-path:
     description: 'kubectl command path if the action setup the tool, otherwise empty string'

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -6449,6 +6449,26 @@ async function downloadTool(version, archType, tool) {
     external_fs_.chmodSync(cachedCommand, '777');
     return cachedCommand;
 }
+// Parse a ".tool-versions" (asdf/mise) style file into a { tool: version } map.
+// Each line is "<tool> <version> [extra versions...]"; only the first version
+// token is used. Inline "#" comments, blank lines, and lines without a version
+// are ignored. Tool names and versions are lower-cased to match input handling.
+function parseVersionFile(filePath) {
+    const versions = {};
+    const content = external_fs_.readFileSync(filePath, 'utf8');
+    for (const rawLine of content.split('\n')) {
+        const line = rawLine.split('#')[0].trim();
+        if (!line) {
+            continue;
+        }
+        const parts = line.split(/\s+/);
+        if (parts.length < 2) {
+            continue;
+        }
+        versions[parts[0].toLowerCase()] = parts[1].toLowerCase();
+    }
+    return versions;
+}
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 async function run() {
     if (!external_os_.type().match(/^Linux/)) {
@@ -6476,6 +6496,18 @@ async function run() {
         })
             .filter(x => x !== '');
     }
+    // Optionally load tool versions from a ".tool-versions" style file. A tool's
+    // own version input still takes precedence over its version-file entry.
+    let versionFileMap = {};
+    const versionFile = core.getInput('version-file', { required: false }).trim();
+    if (versionFile) {
+        if (!external_fs_.existsSync(versionFile)) {
+            throw new Error(`version-file not found: ${versionFile}`);
+        }
+        versionFileMap = parseVersionFile(versionFile);
+        // eslint-disable-next-line no-console
+        console.log(`Loaded versions from version-file '${versionFile}': ${JSON.stringify(versionFileMap)}`);
+    }
     // eslint-disable-next-line github/array-foreach
     Tools.forEach(async function (tool) {
         let toolPath = '';
@@ -6484,6 +6516,10 @@ async function run() {
         if (setupToolList.length === 0 || setupToolList.includes(tool.name)) {
             let toolVersion = core.getInput(tool.name, { required: false })
                 .toLowerCase();
+            // Fall back to the version-file entry when the tool's own input is unset.
+            if (!toolVersion && versionFileMap[tool.name]) {
+                toolVersion = versionFileMap[tool.name];
+            }
             if (toolVersion && toolVersion.startsWith('v')) {
                 toolVersion = toolVersion.substr(1);
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -383,6 +383,27 @@ async function downloadTool(
   return cachedCommand
 }
 
+// Parse a ".tool-versions" (asdf/mise) style file into a { tool: version } map.
+// Each line is "<tool> <version> [extra versions...]"; only the first version
+// token is used. Inline "#" comments, blank lines, and lines without a version
+// are ignored. Tool names and versions are lower-cased to match input handling.
+function parseVersionFile(filePath: string): {[tool: string]: string} {
+  const versions: {[tool: string]: string} = {}
+  const content = fs.readFileSync(filePath, 'utf8')
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.split('#')[0].trim()
+    if (!line) {
+      continue
+    }
+    const parts = line.split(/\s+/)
+    if (parts.length < 2) {
+      continue
+    }
+    versions[parts[0].toLowerCase()] = parts[1].toLowerCase()
+  }
+  return versions
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 async function run() {
   if (!os.type().match(/^Linux/)) {
@@ -414,6 +435,23 @@ async function run() {
       .filter(x => x !== '')
   }
 
+  // Optionally load tool versions from a ".tool-versions" style file. A tool's
+  // own version input still takes precedence over its version-file entry.
+  let versionFileMap: {[tool: string]: string} = {}
+  const versionFile = core.getInput('version-file', {required: false}).trim()
+  if (versionFile) {
+    if (!fs.existsSync(versionFile)) {
+      throw new Error(`version-file not found: ${versionFile}`)
+    }
+    versionFileMap = parseVersionFile(versionFile)
+    // eslint-disable-next-line no-console
+    console.log(
+      `Loaded versions from version-file '${versionFile}': ${JSON.stringify(
+        versionFileMap
+      )}`
+    )
+  }
+
   // eslint-disable-next-line github/array-foreach
   Tools.forEach(async function(tool) {
     let toolPath = ''
@@ -423,6 +461,10 @@ async function run() {
       let toolVersion = core
         .getInput(tool.name, {required: false})
         .toLowerCase()
+      // Fall back to the version-file entry when the tool's own input is unset.
+      if (!toolVersion && versionFileMap[tool.name]) {
+        toolVersion = versionFileMap[tool.name]
+      }
       if (toolVersion && toolVersion.startsWith('v')) {
         toolVersion = toolVersion.substr(1)
       }


### PR DESCRIPTION
This adds an optional `version-file` input so tool versions can be pinned in a `.tool-versions` (asdf/mise) style file instead of repeating each version in the workflow. For each supported tool with an entry in the file, that version is used, unless the tool's own version input is explicitly set.

Resolution order: explicit tool input > version-file entry > built-in default.

Notes:
- The per-tool inputs no longer carry a hardcoded `default:` in action.yml. The built-in defaults in `src/constants.ts` stay as the fallback, so resolved versions are unchanged for existing users. Dropping the action.yml defaults is what lets an explicit input be told apart from "unset", so version-file can fill the gap. The documented default stays in each input's description.
- `#` comments, blank lines, multi-version lines (first token used), and unsupported tool names in the file are ignored.

Validation:
- `npm run all` (tsc + prettier + eslint + ncc pack) passes; `dist/index.mjs` rebuilt.
- Added a `test-version-file` CI job that pins kubectl/helm/kustomize via `.tool-versions`, overrides kubectl explicitly, and asserts the resolved versions (explicit override wins, the others come from the file).