### PR TITLE
docs: fix version-file and setup-tools documentation inconsistencies (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A GitHub Action that setup Kubernetes tools (kubectl, kustomize, helm, kubeconfo
 |:--:|:--:|:--:|:--|
 |`fail-fast`|`false`|`true`| the action immediately fails when it fails to download (ie. due to a bad version) |
 |`arch-type`|`false`|`""`| Optional. The processor architecture type of the tool binary to setup. The action will auto-detect the architecture (`amd64` or `arm64`) and use it as appropriate at runtime. Specify the architecture type (`amd64` or `arm64`) only if you need to force it.|
-|`setup-tools`|`false`|`""`|List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying `setup-tools` you can choose which tools the action setup. Supported separator is `return` in multi-line string. Supported tools are `kubectl`, `kustomize`, `helm`, `kubeval`, `conftest`, `yq`, `rancher`, `tilt`, `skaffold`, `kube-score`|
+|`setup-tools`|`false`|`""`|List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying `setup-tools` you can choose which tools the action setup. Supported separator is `return` in multi-line string. Supported tools are `kubectl`, `kustomize`, `helm`, `kubeval`, `kubeconform`, `conftest`, `yq`, `rancher`, `tilt`, `skaffold`, `kube-score`|
 |`version-file`|`false`|`""`| Optional. Path to a `.tool-versions` ([asdf](https://asdf-vm.com/)/[mise](https://mise.jdx.dev/)) style file. For each supported tool with an entry in the file, that version is used **unless** the tool's own version input is explicitly set. Resolution order: explicit tool input > `version-file` entry > built-in default. Each line is `<tool> <version>`; `#` comments, blank lines, and unsupported tool names are ignored. See [Using a version file](#using-a-version-file).|
 |`kubectl`|`false`|`1.35.3`| kubectl version or `latest`. kubectl versions can be found [here](https://github.com/kubernetes/kubernetes/releases)|
 |`kustomize`|`false`|`5.8.1`| kustomize version or `latest`. kustomize versions can be found [here](https://github.com/kubernetes-sigs/kustomize/releases)|
@@ -189,7 +189,7 @@ If you already pin tool versions in a `.tool-versions` file (the [asdf](https://
 ```
 # .tool-versions
 kubectl 1.30.0
-helm 3.15.0
+helm 3.14.4
 kustomize 5.4.0
 # unsupported tools and comments are ignored
 nodejs 20.0.0
@@ -222,6 +222,8 @@ A tool's own version input always overrides its `version-file` entry, so you can
 ```
 
 Resolution order is: explicit tool input > `version-file` entry > built-in default. Tools without an entry in the file (and without an explicit input) fall back to their built-in default version.
+
+A `version-file` entry may also be set to `latest` (e.g. `kubectl latest`), in which case the action resolves the latest version at runtime, just like the `latest` tool input. Note that using `latest` makes builds non-reproducible since versions can change over time; prefer pinning exact versions for stability.
 
 
 ## Developing the action

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   setup-tools:
     required: false
     default: ''
-    description: 'List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying "setup-tools" you can choose which tools the action setup. Supported separator is return in multi-line string. Supported tools are "kubectl", "kustomize", "helm", "helmv3", "kubeval", "conftest", "yq", "rancher", "tilt", "skaffold", "kube-score"'
+    description: 'List of tool name to setup. By default, the action download and setup all supported Kubernetes tools. By specifying "setup-tools" you can choose which tools the action setup. Supported separator is return in multi-line string. Supported tools are "kubectl", "kustomize", "helm", "kubeval", "kubeconform", "conftest", "yq", "rancher", "tilt", "skaffold", "kube-score"'
   version-file:
     required: false
     default: ''


### PR DESCRIPTION
Fixes #101.

Documentation/consistency fixes identified during review of #98. Docs and description strings only — no functional code changes, so `dist/` is unchanged.

## Changes

### 1. Document `latest` support in `version-file`
A `.tool-versions` entry may be set to `latest` (e.g. `kubectl latest`); the value is resolved at runtime just like the `latest` tool input. This already worked but was undocumented — added a note (with the usual reproducibility caveat) to the "Using a version file" section in `README.md`.

### 2. Align README `.tool-versions` example with CI
The README example used `helm 3.15.0` while the `test-version-file` CI job uses `helm 3.14.4`. Updated the README example to `helm 3.14.4` to keep the docs and CI consistent.

### 3. Fix `setup-tools` supported-tools list
The `setup-tools` description was out of sync with the actual `Tools` set in `src/main.ts`:
- Added the missing `kubeconform`.
- Removed the non-existent `helmv3`.

Updated in both `action.yml` and `README.md`. The list now matches: `kubectl`, `kustomize`, `helm`, `kubeval`, `kubeconform`, `conftest`, `yq`, `rancher`, `tilt`, `skaffold`, `kube-score`.

## Notes
Item 3 is a pre-existing discrepancy that predates #98.

Generated with [Claude Code](https://claude.com/claude-code)